### PR TITLE
Fix dashboard config

### DIFF
--- a/site-lisp/interface.el
+++ b/site-lisp/interface.el
@@ -123,9 +123,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (use-package dashboard
-  :init
-  (require 'seq)
-
   :custom
   (dashboard-banner-logo-title (concat "GNU Emacs " emacs-version))
   (dashboard-startup-banner    'logo)


### PR DESCRIPTION
* `(require 'seq)` is no longer necessary because of the revert commit bellow
  https://github.com/emacs-dashboard/emacs-dashboard/commit/f9f1f5e79b4f5f31388bbe030400295ccad7c44e